### PR TITLE
Use symbols instead of constants in Ask module method definitions

### DIFF
--- a/lib/inquirer.rb
+++ b/lib/inquirer.rb
@@ -5,11 +5,9 @@ Dir["#{File.dirname(__FILE__)}/inquirer/prompts/**/*.rb"].each { |f| require f }
 module Ask
   extend self
   # implement prompts
-  [List, Checkbox, Input, Confirm].each do |klass|
-    method = klass.name.downcase
+  %i[list checkbox input confirm].each do |method|
     define_method(method) do |*args|
-      klass.ask *args
+      self.const_get(method.capitalize).ask(*args)
     end
   end
-
 end

--- a/test/classes/ask_spec.rb
+++ b/test/classes/ask_spec.rb
@@ -2,15 +2,9 @@
 require 'minitest_helper'
 
 describe Ask do
-  before :each do
-    IOHelper.output = ""
-    IOHelper.keys = nil
-  end
-
-  ['list', 'checkbox', 'input', 'confirm'].each do |method|
+  %i[list checkbox input confirm].each do |method|
     it "respond to #{method} method" do
       Ask.method_defined?(method).must_equal true
     end
   end
-
 end


### PR DESCRIPTION
I like what you're doing, but I would say it's preferable to use a list of symbols or strings over explicitly having a list of constants... Let me know what you think!
